### PR TITLE
Add keydown event to fix bug

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -10,6 +10,11 @@ $("#enterKeyboard").submit(function(event) {
     submitButton();
 });
 
+$("#enterKeyboard").keydown(function() {
+    resetBorder();
+});
+
+
 function submitButton() {
     //  Get number string from input field in html document
     var cricketStr = document.getElementById("chirps").value;

--- a/javascript.js
+++ b/javascript.js
@@ -10,10 +10,10 @@ $("#enterKeyboard").submit(function(event) {
     submitButton();
 });
 
+//Removes .redBorder when users press keys in input field
 $("#enterKeyboard").keydown(function() {
     resetBorder();
 });
-
 
 function submitButton() {
     //  Get number string from input field in html document
@@ -68,6 +68,7 @@ function submitButton() {
     calculation();
 }
 
+//Called in HTML for onclick and in jquery for keyboard "enter"
 function resetBorder() {
     inputBorder.className = "";
 }


### PR DESCRIPTION
If users submitted an empty field via their keyboard, the input field turns red, as expected. However, if users enter a valid number and hit enter, the input field remains red.

The solution is to add a keydown event via jQuery and call on the resetBorder() to fix the bug.